### PR TITLE
feat: add product tiles and cart checkout

### DIFF
--- a/items.html
+++ b/items.html
@@ -41,6 +41,11 @@
       </div>
     </section>
 
+    <!-- Floating checkout button shows number of items in cart -->
+    <button id="checkout-btn" class="cart-button" style="display:none;">
+      Checkout (<span id="cart-count">0</span>)
+    </button>
+
     <!-- Categories with items and quantity controls -->
     <section id="spices" class="product-category">
       <div class="container">

--- a/script.js
+++ b/script.js
@@ -114,35 +114,41 @@ function initShopPage(form) {
     drinks: document.getElementById('drinks-list')
   };
   const summaryContainer = document.getElementById('order-summary');
-  // Helper to build a product row with plus/minus controls
-  function buildRow(product) {
-    const row = document.createElement('div');
-    row.className = 'order-item';
-    row.dataset.id = product.id;
-    const nameSpan = document.createElement('span');
-    nameSpan.className = 'order-item-name';
-    nameSpan.textContent = product.name;
+  const checkoutBtn = document.getElementById('checkout-btn');
+  const cartCountEl = document.getElementById('cart-count');
+  // Build a product card with image and quantity controls
+  function buildCard(product) {
+    const card = document.createElement('div');
+    card.className = 'product-card';
+    card.dataset.id = product.id;
+
+    const img = document.createElement('img');
+    img.src = 'https://via.placeholder.com/150?text=' + encodeURIComponent(product.name);
+    img.alt = product.name;
+    card.appendChild(img);
+
+    const title = document.createElement('h3');
+    title.textContent = product.name;
+    card.appendChild(title);
+
     const controls = document.createElement('div');
-    controls.className = 'qty-controls';
+    controls.className = 'card-controls';
     const minusBtn = document.createElement('button');
     minusBtn.type = 'button';
-    minusBtn.className = 'qty-minus';
     minusBtn.textContent = '−';
     const qtyInput = document.createElement('input');
     qtyInput.type = 'text';
-    qtyInput.className = 'qty-value';
     qtyInput.readOnly = true;
+    qtyInput.className = 'qty-value';
     qtyInput.value = '0';
     const plusBtn = document.createElement('button');
     plusBtn.type = 'button';
-    plusBtn.className = 'qty-plus';
     plusBtn.textContent = '+';
     controls.appendChild(minusBtn);
     controls.appendChild(qtyInput);
     controls.appendChild(plusBtn);
-    row.appendChild(nameSpan);
-    row.appendChild(controls);
-    // Click handlers to adjust quantities
+    card.appendChild(controls);
+
     plusBtn.addEventListener('click', () => {
       cart[product.id] += 1;
       qtyInput.value = cart[product.id];
@@ -155,18 +161,21 @@ function initShopPage(form) {
         updateSummary();
       }
     });
-    return row;
+    return card;
   }
   // Populate each category list with its products
   products.forEach(prod => {
     const container = containers[prod.category];
     if (container) {
-      container.appendChild(buildRow(prod));
+      container.appendChild(buildCard(prod));
     }
   });
   // Function to refresh the order summary box
   function updateSummary() {
     const selected = products.filter(p => cart[p.id] > 0);
+    const count = selected.reduce((sum, item) => sum + cart[item.id], 0);
+    if (cartCountEl) cartCountEl.textContent = count;
+    if (checkoutBtn) checkoutBtn.style.display = count > 0 ? 'block' : 'none';
     if (selected.length === 0) {
       summaryContainer.textContent = 'No items selected.';
       return;
@@ -186,7 +195,7 @@ function initShopPage(form) {
     searchInput.addEventListener('input', () => {
       const query = searchInput.value.toLowerCase().trim();
       products.forEach(prod => {
-        const el = document.querySelector('.order-item[data-id="' + prod.id + '"]');
+        const el = document.querySelector('.product-card[data-id="' + prod.id + '"]');
         if (!el) return;
         if (!query || prod.name.toLowerCase().includes(query)) {
           el.style.display = '';
@@ -203,6 +212,11 @@ function initShopPage(form) {
           section.style.display = visible ? '' : 'none';
         }
       });
+    });
+  }
+  if (checkoutBtn) {
+    checkoutBtn.addEventListener('click', () => {
+      form.scrollIntoView({ behavior: 'smooth' });
     });
   }
   // Set pickup date to today and time to half an hour from now

--- a/styles.css
+++ b/styles.css
@@ -541,8 +541,75 @@ body {
   font-size: 1.5rem;
   color: var(--color-green);
 }
-.category-list .order-item {
-  margin-bottom: 0.75rem;
+.category-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
+.product-card {
+  background-color: #fff;
+  border: 1px solid var(--color-gray);
+  border-radius: 8px;
+  padding: 0.5rem;
+  text-align: center;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+}
+
+.product-card img {
+  width: 100%;
+  height: 100px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.product-card h3 {
+  font-size: 1rem;
+  margin-top: 0.5rem;
+}
+
+.card-controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.card-controls button {
+  width: 32px;
+  height: 32px;
+  background-color: var(--color-green);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.card-controls input {
+  width: 40px;
+  text-align: center;
+  border: 1px solid var(--color-gray);
+  border-radius: 4px;
+}
+
+.cart-button {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background-color: var(--color-orange);
+  color: #fff;
+  border: none;
+  border-radius: 50px;
+  padding: 0.75rem 1.25rem;
+  font-weight: 600;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  z-index: 1000;
+}
+
+.cart-button:hover {
+  background-color: var(--color-dark-green);
 }
 
 /* Responsive styles */


### PR DESCRIPTION
## Summary
- display shop products as image tiles with quantity controls
- show floating checkout button with cart count
- add grid and card styles for product tiles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689980b7419883288be6a61374097b74